### PR TITLE
Fix collapsing drops. When dropping fragments make sure they

### DIFF
--- a/MarcoMD.py
+++ b/MarcoMD.py
@@ -20,23 +20,31 @@ def end_game(screen, msgs):
     time.sleep(3)
 
 def drop_fragments(screen, fragments, statics):
-    for f in fragments: # set falling speed faster so they get out of the way
+    if len(fragments)==0:
+        return # no fragments --> nothing to do
+
+    # set all timers to the same so they fall in sync
+    # set falling speed faster so they get out of the way quick
+    common_time = time.perf_counter()
+    for f in fragments:
         f.s_fall = f.s_move
+        f.time_fall = common_time
+        f.time_move = common_time
 
     # when we fall out of this while loop, all the fragments will be done falling
     while len(fragments):
         for f in fragments.copy():
-            if not f.moving_down:   # this fragment has reached its bottom
-                statics.add(f)      # now it's static
-                fragments.remove(f) # one less mover to keep updating
+            f.update(statics)     # immediately after updating
+            if not f.moving_down:   # if update made f static
+                statics.add(f)      # transfer f to statics
+                fragments.remove(f) # so next frag knows it's static
+
         # redraw everything
         screen.fill(settings.bg_color)
-        for b in statics.sprites():
-            b.render()
-        for f in fragments:
-            f.update(statics)
-            f.render()
+        for b in statics.sprites():  b.render()
+        for f in fragments:          f.render()
         pygame.display.flip()
+
 
 def update_times(t0, tsum, tnum):
     t1 = time.perf_counter()

--- a/events.py
+++ b/events.py
@@ -123,13 +123,23 @@ def erase_inarows(settings, statics):
     while (found_sumpn):
         found_sumpn = False
         for s in statics.copy():
-            statics.remove(s)
-            if isinstance(s,Unguent) and s.free_to_move(statics):
-                found_sump = True
+            if not isinstance(s, Unguent): # bacteria never fall
+                continue
+            # check if unguent has no statics in its way
+            statics.remove(s) # don't let it collide with itself
+            if s.free_to_move(statics):
+                found_sumpn = True
                 movers.append(s)
                 break
             else: # put it back
                 statics.add(s)
+
+    # issue #15: make sure these movers are sorted bottom-up
+    # (decreasing row number). Whenever one fragment a is right
+    # on top of fragment b, we need b to update before a so if it
+    # stops moving and gets transferred from movers to statics,
+    # then a can update and see it as a static and not move down into it
+    movers.sort(key=lambda m : -m.bottom_row())
 
     return movers
 

--- a/unguent.py
+++ b/unguent.py
@@ -120,13 +120,20 @@ class Unguent(Sprite):
         else: # orientation 1, c0, r0 is top
             crs.append( (s.c0, s.r0 - s.nblocks + 1) )
 
+    def bottom_row(s):
+        if s.orientation == 1: # top down
+            return s.r0 + s.nblocks-1
+        # all others r0 is the correct answer
+        return s.r0
+
     def free_to_move(s, statics):
-        s.set_rect(s.c0, s.r0+1, s.orientation)
+        row = s.r0
+        s.set_rect(s.c0, row+1, s.orientation) # test the lower position
         if s.rect.bottom > s.se.screenh or pygame.sprite.spritecollideany(s, statics, False):
-            s.set_rect(s.c0, s.r0-1, s.orientation)
             s.moving_down = False
         else:
             s.moving_down = True
+        s.set_rect(s.c0, row, s.orientation) # restore the higher position
         return s.moving_down
 
     def render(s):


### PR DESCRIPTION
update into static immediately so subsequent fragments know
they are obstacles.
Sort the fragments bottom-up so lower ones move and become static first